### PR TITLE
fix tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 1.0.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- fixes for tags
 
 
 1.0.14 (2019-06-18)

--- a/guillotina_swagger/services.py
+++ b/guillotina_swagger/services.py
@@ -48,7 +48,7 @@ class SwaggerDefinitionService(Service):
                 desc += f"permission: {service_def['permission']}"
 
         api_def[path or "/"][method.lower()] = {
-            "tags": swagger_conf.get("tags", [""]) or tags,
+            "tags": swagger_conf.get("tags", []) or tags,
             "parameters": self.get_data(service_def.get("parameters", {})),
             "produces": self.get_data(service_def.get("produces", [])),
             "summary": self.get_data(service_def.get("summary", "")),
@@ -64,7 +64,7 @@ class SwaggerDefinitionService(Service):
                         iface_conf["endpoints"][name],
                         os.path.join(base_path, name),
                         api_def,
-                        tags=[name.strip("@")],
+                        tags=tags or [name.strip("@")],
                     )
             else:
                 if method.lower() == "options":


### PR DESCRIPTION
some fixes for tags:
- in `services/get_endpoints`:  check if there are tags supplied in the args
- in `services/load_swagger_info`: change default to empty array so user supplied tags will be allowed